### PR TITLE
[Core] Fix endless loop in `stream` attribute access of `ray._private.utils.Unbuffered`

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -302,6 +302,9 @@ class Unbuffered(object):
         self.stream.flush()
 
     def __getattr__(self, attr):
+        # Avoid endless loop when get `stream` attribtue
+        if attr == "stream":
+            return super().__getattribute__('stream')
         return getattr(self.stream, attr)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes an infinite recursion issue that occurs when accessing the `stream`  attribute of `Unbuffered` instances. 

<img width="1135" height="777" alt="image" src="https://github.com/user-attachments/assets/dc51b241-98fc-449d-a9cd-64d7b4d8668c" />


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
